### PR TITLE
[test][#1] Add Cholesky decomposition correctness tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+# Makefile for Cholesky decomposition project
+
+CC = gcc
+CFLAGS = -Wall -Wextra -O2 -std=c11
+INCLUDES = -Iinclude
+LIBS = -lm
+
+# Directories
+SRC_DIR = src
+TEST_DIR = tests/cholesky
+BUILD_DIR = build
+
+# Source files
+CHOLESKY_SRC = $(SRC_DIR)/cholesky.c
+TEST_HELPERS_SRC = $(TEST_DIR)/test_helpers.c
+
+# Test executable
+TEST_CORRECTNESS = $(BUILD_DIR)/test_correctness
+
+# Default target
+all: test-correctness
+
+# Create build directory
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+# Test target
+test-correctness: $(BUILD_DIR) $(TEST_CORRECTNESS)
+	@echo "Running correctness tests..."
+	@$(TEST_CORRECTNESS)
+
+# Build test executable
+$(TEST_CORRECTNESS): $(TEST_DIR)/test_correctness.c $(TEST_HELPERS_SRC) $(CHOLESKY_SRC) | $(BUILD_DIR)
+	$(CC) $(CFLAGS) $(INCLUDES) -I$(TEST_DIR) \
+		$(TEST_DIR)/test_correctness.c $(TEST_HELPERS_SRC) $(CHOLESKY_SRC) \
+		-o $(TEST_CORRECTNESS) $(LIBS)
+
+# Clean build artifacts
+clean:
+	rm -rf $(BUILD_DIR)
+
+.PHONY: all test-correctness clean
+

--- a/tests/cholesky/test_correctness.c
+++ b/tests/cholesky/test_correctness.c
@@ -1,0 +1,308 @@
+/**
+ * @file test_correctness.c
+ * @brief Correctness tests for Cholesky decomposition
+ * 
+ * Tests verify that the decomposition produces L such that L × L^T = A
+ * and that L has the correct lower triangular structure.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include "../../include/cholesky.h"
+#include "test_helpers.h"
+
+/* Test counters */
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+/* Test 1: Identity Matrix
+ * Input: 32×32 identity matrix I
+ * Expected: L = I (identity matrix)
+ * Verification: L × L^T = I × I = I
+ */
+void test_identity_matrix(void) {
+    tests_run++;
+    printf("Test 1: Identity Matrix... ");
+    
+    double A[N][N];
+    double L[N][N];
+    
+    generate_identity_matrix(A);
+    
+    int result = cholesky_decompose_32x32(A, L);
+    
+    if (result != 0) {
+        printf("FAILED (error code %d)\n", result);
+        tests_failed++;
+        return;
+    }
+    
+    // Verify L is identity
+    if (!matrix_compare_32x32(A, L, TEST_TOLERANCE)) {
+        printf("FAILED (L should equal identity)\n");
+        tests_failed++;
+        return;
+    }
+    
+    // Verify decomposition correctness
+    if (!assert_decomposition_correct(A, L, TEST_TOLERANCE, "Identity decomposition")) {
+        tests_failed++;
+        printf("FAILED\n");
+        return;
+    }
+    
+    // Verify lower triangular
+    if (!assert_lower_triangular(L, TEST_TOLERANCE, "Identity lower triangular")) {
+        tests_failed++;
+        printf("FAILED\n");
+        return;
+    }
+    
+    tests_passed++;
+    printf("PASSED\n");
+}
+
+/* Test 2: Diagonal Matrix
+ * Input: Diagonal matrix D with positive diagonal elements
+ * Expected: L is diagonal with sqrt of diagonal elements
+ * Verification: L × L^T = D
+ */
+void test_diagonal_matrix(void) {
+    tests_run++;
+    printf("Test 2: Diagonal Matrix... ");
+    
+    double A[N][N];
+    double L[N][N];
+    
+    // Create diagonal matrix with positive values
+    memset(A, 0, sizeof(A));
+    for (int i = 0; i < N; i++) {
+        A[i][i] = (i + 1) * 2.0;  // Values: 2, 4, 6, ..., 64
+    }
+    
+    int result = cholesky_decompose_32x32(A, L);
+    
+    if (result != 0) {
+        printf("FAILED (error code %d)\n", result);
+        tests_failed++;
+        return;
+    }
+    
+    // Verify L is diagonal with sqrt values
+    bool diagonal_correct = true;
+    for (int i = 0; i < N; i++) {
+        double expected = sqrt(A[i][i]);
+        if (fabs(L[i][i] - expected) > TEST_TOLERANCE) {
+            printf("FAIL: Diagonal element [%d][%d] = %e, expected %e\n",
+                   i, i, L[i][i], expected);
+            diagonal_correct = false;
+        }
+        // Check off-diagonal is zero
+        for (int j = 0; j < N; j++) {
+            if (i != j && fabs(L[i][j]) > TEST_TOLERANCE) {
+                printf("FAIL: Off-diagonal element [%d][%d] = %e (should be zero)\n",
+                       i, j, L[i][j]);
+                diagonal_correct = false;
+            }
+        }
+    }
+    
+    if (!diagonal_correct) {
+        tests_failed++;
+        printf("FAILED\n");
+        return;
+    }
+    
+    // Verify decomposition correctness
+    if (!assert_decomposition_correct(A, L, TEST_TOLERANCE, "Diagonal decomposition")) {
+        tests_failed++;
+        printf("FAILED\n");
+        return;
+    }
+    
+    tests_passed++;
+    printf("PASSED\n");
+}
+
+/* Test 3: Random SPD Matrix
+ * Input: Randomly generated symmetric positive definite matrix
+ * Verification: L × L^T ≈ A (within numerical tolerance)
+ * Verification: L is lower triangular
+ */
+void test_random_spd_matrix(void) {
+    tests_run++;
+    printf("Test 3: Random SPD Matrix... ");
+    
+    double A[N][N];
+    double L[N][N];
+    
+    generate_random_spd_matrix(A, 12345);
+    
+    int result = cholesky_decompose_32x32(A, L);
+    
+    if (result != 0) {
+        printf("FAILED (error code %d)\n", result);
+        tests_failed++;
+        return;
+    }
+    
+    // Verify L is lower triangular
+    if (!assert_lower_triangular(L, TEST_TOLERANCE, "Random SPD lower triangular")) {
+        tests_failed++;
+        printf("FAILED\n");
+        return;
+    }
+    
+    // Verify decomposition correctness
+    if (!assert_decomposition_correct(A, L, TEST_TOLERANCE, "Random SPD decomposition")) {
+        tests_failed++;
+        printf("FAILED\n");
+        return;
+    }
+    
+    tests_passed++;
+    printf("PASSED\n");
+}
+
+/* Test 4: Known Exact Decomposition
+ * Input: Matrix with known exact Cholesky decomposition
+ * Example: Simple 2×2 block repeated pattern
+ * Verification: L × L^T = A exactly (within machine precision)
+ */
+void test_known_exact_decomposition(void) {
+    tests_run++;
+    printf("Test 4: Known Exact Decomposition... ");
+    
+    // Create a simple 2×2 block repeated pattern (scaled to 32×32)
+    // For a 2×2 matrix [[a, b], [b, c]] with a>0 and ac-b^2>0,
+    // the Cholesky decomposition is known
+    
+    double A[N][N];
+    memset(A, 0, sizeof(A));
+    
+    // Create block diagonal with 2×2 blocks
+    for (int block = 0; block < N/2; block++) {
+        int i = block * 2;
+        int j = block * 2 + 1;
+        
+        // Simple 2×2 SPD block: [[4, 1], [1, 4]]
+        A[i][i] = 4.0;
+        A[i][j] = 1.0;
+        A[j][i] = 1.0;
+        A[j][j] = 4.0;
+    }
+    
+    double L[N][N];
+    int result = cholesky_decompose_32x32(A, L);
+    
+    if (result != 0) {
+        printf("FAILED (error code %d)\n", result);
+        tests_failed++;
+        return;
+    }
+    
+    // Verify decomposition correctness with tight tolerance
+    if (!assert_decomposition_correct(A, L, 1e-10, "Known exact decomposition")) {
+        tests_failed++;
+        printf("FAILED\n");
+        return;
+    }
+    
+    tests_passed++;
+    printf("PASSED\n");
+}
+
+/* Test 5: Lower Triangular Property
+ * Input: Random SPD matrix
+ * Verification: Upper triangular part of L is zero
+ * Verification: Diagonal elements are positive
+ */
+void test_lower_triangular_property(void) {
+    tests_run++;
+    printf("Test 5: Lower Triangular Property... ");
+    
+    double A[N][N];
+    double L[N][N];
+    
+    generate_random_spd_matrix(A, 9999);
+    
+    int result = cholesky_decompose_32x32(A, L);
+    
+    if (result != 0) {
+        printf("FAILED (error code %d)\n", result);
+        tests_failed++;
+        return;
+    }
+    
+    // Verify lower triangular property
+    if (!assert_lower_triangular(L, TEST_TOLERANCE, "Lower triangular property")) {
+        tests_failed++;
+        printf("FAILED\n");
+        return;
+    }
+    
+    tests_passed++;
+    printf("PASSED\n");
+}
+
+/* Test 6: Multiple Random Matrices
+ * Run decomposition on 10 different random SPD matrices
+ * Verification: Correctness for each matrix
+ */
+void test_multiple_random_matrices(void) {
+    tests_run++;
+    printf("Test 6: Multiple Random Matrices (10 iterations)... ");
+    
+    int failed_count = 0;
+    
+    for (int iter = 0; iter < 10; iter++) {
+        double A[N][N];
+        double L[N][N];
+        
+        generate_random_spd_matrix(A, 1000 + iter);
+        
+        int result = cholesky_decompose_32x32(A, L);
+        
+        if (result != 0) {
+            printf("FAIL: Iteration %d returned error code %d\n", iter, result);
+            failed_count++;
+            continue;
+        }
+        
+        if (!assert_decomposition_correct(A, L, TEST_TOLERANCE, 
+                                          "Multiple random matrices")) {
+            failed_count++;
+        }
+    }
+    
+    if (failed_count > 0) {
+        tests_failed++;
+        printf("FAILED (%d/%d iterations failed)\n", failed_count, 10);
+        return;
+    }
+    
+    tests_passed++;
+    printf("PASSED\n");
+}
+
+int main(void) {
+    printf("=== Cholesky Decomposition Correctness Tests ===\n\n");
+    
+    test_identity_matrix();
+    test_diagonal_matrix();
+    test_random_spd_matrix();
+    test_known_exact_decomposition();
+    test_lower_triangular_property();
+    test_multiple_random_matrices();
+    
+    printf("\n=== Test Summary ===\n");
+    printf("Tests run: %d\n", tests_run);
+    printf("Tests passed: %d\n", tests_passed);
+    printf("Tests failed: %d\n", tests_failed);
+    
+    return (tests_failed == 0) ? 0 : 1;
+}
+

--- a/tests/cholesky/test_helpers.c
+++ b/tests/cholesky/test_helpers.c
@@ -1,0 +1,139 @@
+#include "test_helpers.h"
+#include <string.h>
+
+/* Matrix Operations */
+
+void matrix_multiply_32x32(const double A[N][N], const double B[N][N], double C[N][N]) {
+    for (int i = 0; i < N; i++) {
+        for (int j = 0; j < N; j++) {
+            C[i][j] = 0.0;
+            for (int k = 0; k < N; k++) {
+                C[i][j] += A[i][k] * B[k][j];
+            }
+        }
+    }
+}
+
+void matrix_transpose_32x32(const double A[N][N], double At[N][N]) {
+    for (int i = 0; i < N; i++) {
+        for (int j = 0; j < N; j++) {
+            At[i][j] = A[j][i];
+        }
+    }
+}
+
+bool matrix_compare_32x32(const double A[N][N], const double B[N][N], double tolerance) {
+    for (int i = 0; i < N; i++) {
+        for (int j = 0; j < N; j++) {
+            if (fabs(A[i][j] - B[i][j]) > tolerance) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+/* Matrix Generation */
+
+void generate_identity_matrix(double A[N][N]) {
+    for (int i = 0; i < N; i++) {
+        for (int j = 0; j < N; j++) {
+            A[i][j] = (i == j) ? 1.0 : 0.0;
+        }
+    }
+}
+
+void generate_random_spd_matrix(double A[N][N], unsigned int seed) {
+    srand(seed);
+    
+    // Generate random lower triangular matrix L
+    double L[N][N];
+    for (int i = 0; i < N; i++) {
+        for (int j = 0; j < N; j++) {
+            if (j > i) {
+                L[i][j] = 0.0;  // Upper triangular part is zero
+            } else {
+                // Generate values in range [-1, 1] and add small positive bias
+                L[i][j] = (2.0 * rand() / RAND_MAX - 1.0) * 0.5 + (i == j ? 0.5 : 0.0);
+            }
+        }
+    }
+    
+    // Ensure diagonal is positive and not too small
+    for (int i = 0; i < N; i++) {
+        if (L[i][i] < 0.1) {
+            L[i][i] = 0.1 + (double)rand() / RAND_MAX;
+        }
+    }
+    
+    // Compute A = L × L^T to get symmetric positive definite matrix
+    double Lt[N][N];
+    matrix_transpose_32x32(L, Lt);
+    matrix_multiply_32x32(L, Lt, A);
+}
+
+/* Test Assertions */
+
+bool assert_decomposition_correct(const double A[N][N], const double L[N][N],
+                                  double tolerance, const char *test_name) {
+    // Compute L × L^T
+    double Lt[N][N];
+    double reconstructed[N][N];
+    
+    matrix_transpose_32x32(L, Lt);
+    matrix_multiply_32x32(L, Lt, reconstructed);
+    
+    // Compare with original A
+    bool result = matrix_compare_32x32(A, reconstructed, tolerance);
+    if (!result) {
+        printf("FAIL: %s - Decomposition incorrect: L × L^T ≠ A\n", test_name);
+        // Find maximum error
+        double max_error = 0.0;
+        int max_i = 0, max_j = 0;
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                double error = fabs(A[i][j] - reconstructed[i][j]);
+                if (error > max_error) {
+                    max_error = error;
+                    max_i = i;
+                    max_j = j;
+                }
+            }
+        }
+        printf("  Maximum error: %e at [%d][%d]\n", max_error, max_i, max_j);
+        printf("  A[%d][%d] = %e, (L×L^T)[%d][%d] = %e\n",
+               max_i, max_j, A[max_i][max_j],
+               max_i, max_j, reconstructed[max_i][max_j]);
+    }
+    return result;
+}
+
+bool assert_lower_triangular(const double L[N][N], double tolerance, const char *test_name) {
+    bool result = true;
+    for (int i = 0; i < N; i++) {
+        for (int j = i + 1; j < N; j++) {
+            if (fabs(L[i][j]) > tolerance) {
+                if (result) {
+                    printf("FAIL: %s - Matrix is not lower triangular\n", test_name);
+                    result = false;
+                }
+                printf("  Upper triangular element [%d][%d] = %e (should be < %e)\n",
+                       i, j, L[i][j], tolerance);
+            }
+        }
+    }
+    
+    // Also check diagonal is positive
+    for (int i = 0; i < N; i++) {
+        if (L[i][i] <= 0.0) {
+            if (result) {
+                printf("FAIL: %s - Diagonal element is not positive\n", test_name);
+                result = false;
+            }
+            printf("  Diagonal element [%d][%d] = %e (should be > 0)\n", i, i, L[i][i]);
+        }
+    }
+    
+    return result;
+}
+

--- a/tests/cholesky/test_helpers.h
+++ b/tests/cholesky/test_helpers.h
@@ -1,0 +1,83 @@
+#ifndef TEST_HELPERS_H
+#define TEST_HELPERS_H
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+
+#define N 32
+#define TEST_TOLERANCE 1e-9
+
+/**
+ * @file test_helpers.h
+ * @brief Helper functions for Cholesky decomposition correctness tests
+ */
+
+/* Matrix Operations */
+
+/**
+ * @brief Multiply two 32×32 matrices: C = A × B
+ * @param A First matrix (32×32)
+ * @param B Second matrix (32×32)
+ * @param C Output matrix (32×32) where C = A × B
+ */
+void matrix_multiply_32x32(const double A[N][N], const double B[N][N], double C[N][N]);
+
+/**
+ * @brief Compute transpose: At = A^T
+ * @param A Input matrix (32×32)
+ * @param At Output matrix (32×32) where At = A^T
+ */
+void matrix_transpose_32x32(const double A[N][N], double At[N][N]);
+
+/**
+ * @brief Compare two matrices with tolerance
+ * @param A First matrix (32×32)
+ * @param B Second matrix (32×32)
+ * @param tolerance Maximum allowed difference
+ * @return true if matrices are equal within tolerance, false otherwise
+ */
+bool matrix_compare_32x32(const double A[N][N], const double B[N][N], double tolerance);
+
+/* Matrix Generation */
+
+/**
+ * @brief Generate 32×32 identity matrix
+ * @param A Output matrix (32×32) initialized to identity
+ */
+void generate_identity_matrix(double A[N][N]);
+
+/**
+ * @brief Generate random symmetric positive definite matrix
+ * @param A Output matrix (32×32) - will be SPD
+ * @param seed Random seed for reproducibility
+ * 
+ * Algorithm: Generate random lower triangular matrix L, then compute A = L × L^T
+ */
+void generate_random_spd_matrix(double A[N][N], unsigned int seed);
+
+/* Test Assertions */
+
+/**
+ * @brief Verify Cholesky decomposition correctness: L × L^T = A
+ * @param A Original matrix (32×32)
+ * @param L Lower triangular matrix from decomposition (32×32)
+ * @param tolerance Maximum allowed difference
+ * @param test_name Name of the test (for error messages)
+ * @return true if decomposition is correct, false otherwise
+ */
+bool assert_decomposition_correct(const double A[N][N], const double L[N][N],
+                                  double tolerance, const char *test_name);
+
+/**
+ * @brief Verify L is lower triangular (upper part is zero)
+ * @param L Matrix to check (32×32)
+ * @param tolerance Maximum allowed value in upper triangular part
+ * @param test_name Name of the test (for error messages)
+ * @return true if L is lower triangular, false otherwise
+ */
+bool assert_lower_triangular(const double L[N][N], double tolerance, const char *test_name);
+
+#endif /* TEST_HELPERS_H */
+


### PR DESCRIPTION
## Summary

This PR adds comprehensive correctness tests for the Cholesky decomposition implementation. The test suite verifies that the decomposition produces a lower triangular matrix L such that L × L^T = A for all test cases.

## Changes

- Added `tests/cholesky/test_helpers.h` - Helper function declarations for matrix operations and test assertions
- Added `tests/cholesky/test_helpers.c` - Implementation of matrix operations (multiply, transpose, compare) and matrix generation utilities
- Added `tests/cholesky/test_correctness.c` - Main correctness test program with 6 test cases:
  - Identity matrix decomposition
  - Diagonal matrix decomposition
  - Random SPD matrix decomposition
  - Known exact decomposition
  - Lower triangular property verification
  - Multiple random matrices (10 iterations)
- Added `Makefile` - Build system with `test-correctness` target for compiling and running tests

## Testing

All 6 correctness tests are implemented and passing:

- **Test 1: Identity Matrix** - Verifies identity matrix is its own Cholesky decomposition
- **Test 2: Diagonal Matrix** - Verifies diagonal matrices decompose correctly
- **Test 3: Random SPD Matrix** - Tests general case with randomly generated symmetric positive definite matrices
- **Test 4: Known Exact Decomposition** - Tests numerical accuracy with matrices having known exact decompositions
- **Test 5: Lower Triangular Property** - Verifies L is lower triangular with positive diagonal
- **Test 6: Multiple Random Matrices** - Tests robustness across 10 different random SPD matrices

**Test Results:**
```
=== Test Summary ===
Tests run: 6
Tests passed: 6
Tests failed: 0
```

**Verification Method:**
- Reconstruction test: Compute L × L^T and compare with original A (within tolerance 1e-9)
- Structure test: Verify upper triangular part of L is zero and diagonal is positive
- Numerical accuracy: Maximum element-wise error < 1e-9 for all tests

## Related Issue

Closes #1

